### PR TITLE
Add optional AWS credential vars and update Terraform version

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,8 @@ This repository provides Terraform configuration for creating a complete AWS VPC
 - `vpc_cidr`: VPC CIDR block (default: 10.0.0.0/16)
 - `private_subnets`: Map of private subnet names and their number
 - `public_subnets`: Map of public subnet names and their number
+- `aws_access_key_id`: *(optional)* AWS access key. Defaults to the `AWS_ACCESS_KEY_ID` environment variable if unset.
+- `aws_secret_access_key`: *(optional)* AWS secret key. Defaults to the `AWS_SECRET_ACCESS_KEY` environment variable if unset.
 
 ## Outputs
 
@@ -50,6 +52,6 @@ terraform apply
 
 ## Requirements
 
-- Terraform >= 0.12
+- Terraform >= 1.12
 - AWS Provider
 - AWS credentials configured

--- a/provider.tf
+++ b/provider.tf
@@ -1,4 +1,6 @@
 # Configure the AWS Provider
 provider "aws" {
-  region = var.aws_region
+  region     = var.aws_region
+  access_key = var.aws_access_key_id
+  secret_key = var.aws_secret_access_key
 }

--- a/variables.tf
+++ b/variables.tf
@@ -70,3 +70,17 @@ variable "internet_gateway_tags" {
     Name = "igw"
   }
 }
+
+variable "aws_access_key_id" {
+  description = "AWS access key used for authentication"
+  type        = string
+  default     = null
+  sensitive   = true
+}
+
+variable "aws_secret_access_key" {
+  description = "AWS secret key used for authentication"
+  type        = string
+  default     = null
+  sensitive   = true
+}

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,5 @@ terraform {
     }
   }
 
-  required_version = ">= 0.12"
+  required_version = ">= 1.12.0"
 }


### PR DESCRIPTION
## Summary
- add optional `aws_access_key_id` and `aws_secret_access_key` variables
- use variables in `provider.tf`
- require Terraform 1.12+
- document new variables in README

## Testing
- `terraform init -backend=false` *(fails: could not connect to registry)*
- `terraform validate` *(fails: missing required provider)*

------
https://chatgpt.com/codex/tasks/task_e_6840f3326e3083329fd4897fcd5d26c5